### PR TITLE
feat: add top and bottom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ To find out scores, just send the message `!karma` followed by any number of wor
 
 ![score fetching example](pics/example.png)
 
+#### Fetching Top Scores
+You can list the top N scores by sending the message `!top[N]`. If provided, N must be a positive integer. If not provided, N defaults to 3.
+
+#### Fetching Bottom Scores
+You can list the bottom N scores by sending the message `!bottom[N]`. If provided, N must be a positive integer. If not provided, N defaults to 3.
+
 ### Setting it up on your own server
 
 #### Prerequisites

--- a/karmabot.rb
+++ b/karmabot.rb
@@ -129,10 +129,9 @@ def doTop(text,channel,user)
   results = sth.execute()
 
   str = ""
-  rank = 1
-  results.each do |row|
+  results.each_with_index do |row, rank|
     thing = "#{row['thing']}".force_encoding('utf-8').gsub('"','&quot;')
-    str += "#{rank}. \"#{thing}\" (#{row['points']}) "
+    str += "#{rank + 1}. \"#{thing}\" (#{row['points']}) "
   end
 
   if(str != "")
@@ -154,10 +153,9 @@ def doBottom(text,channel,user)
   sth = $client.prepare("SELECT thing,points FROM `#{$tablename}` ORDER BY points ASC, thing ASC LIMIT #{count};")
   results = sth.execute()
   str = ""
-  rank = 1
-  results.each do |row|
+  results.each_with_index do |row, rank|
     thing = "#{row['thing']}".force_encoding('utf-8').gsub('"','&quot;')
-    str += "#{rank}. \"#{thing}\" (#{row['points']}) "
+    str += "#{rank + 1}. \"#{thing}\" (#{row['points']}) "
   end
 
   if(str != "")

--- a/karmabot.rb
+++ b/karmabot.rb
@@ -88,11 +88,13 @@ end
 def doKarma(text,channel,user)
   puts "checking karma for '#{text}'"
 
-  if(text.match(/^!karma\b/))
-    #chop off the '!karma'
-    text = text[7..text.length]
-    puts "after chopping text is '#{text}'"
+  if(!text.match(/^!karma\b/))
+    return false
   end
+
+  #chop off the '!karma'
+  text = text[7..text.length]
+  puts "after chopping text is '#{text}'"
 
   if(!text || text.match(/^\s*$/))
     puts "blank input - replacing with username (#{user})"

--- a/karmabot.rb
+++ b/karmabot.rb
@@ -125,8 +125,7 @@ def doTop(text,channel,user)
     count = m[:count].to_int
   end
 
-  dbh = DBI.connect("DBI:Mysql:#{$dbName}:localhost", $dbUser, $dbtoken)
-  sth = dbh.prepare("SELECT thing,points FROM `#{tablename}` ORDER BY points DESC, thing ASC LIMIT #{count};")
+  sth = $client.prepare("SELECT thing,points FROM `#{tablename}` ORDER BY points DESC, thing ASC LIMIT #{count};")
   sth.execute()
   str = ""
   rank = 1
@@ -152,8 +151,7 @@ def doBottom(text,channel,user)
     count = m[:count].to_int
   end
 
-  dbh = DBI.connect("DBI:Mysql:#{$dbName}:localhost", $dbUser, $dbtoken)
-  sth = dbh.prepare("SELECT thing,points FROM `#{tablename}` ORDER BY points ASC, thing ASC LIMIT #{count};")
+  sth = $client.prepare("SELECT thing,points FROM `#{tablename}` ORDER BY points ASC, thing ASC LIMIT #{count};")
   sth.execute()
   str = ""
   rank = 1

--- a/karmabot.rb
+++ b/karmabot.rb
@@ -120,20 +120,20 @@ end
 def doTop(text,channel,user)
   puts "getting top karma for '#{text}'"
   count = 3
-  m = text.match(/^top(?<count>\d+)/)
+  m = text.match(/^!top(?<count>\d+)/)
   if (m)
-    count = m[:count].to_int
+    count = m[:count].to_i
   end
 
   sth = $client.prepare("SELECT thing,points FROM `#{$tablename}` ORDER BY points DESC, thing ASC LIMIT #{count};")
-  sth.execute()
+  results = sth.execute()
+
   str = ""
   rank = 1
-  sth.fetch do |row|
+  results.each do |row|
     thing = "#{row['thing']}".force_encoding('utf-8').gsub('"','&quot;')
     str += "#{rank}. \"#{thing}\" (#{row['points']}) "
   end
-  dbh.disconnect()
 
   if(str != "")
     sendMessage(str,channel)
@@ -146,20 +146,19 @@ end
 def doBottom(text,channel,user)
   puts "getting bottom karma for '#{text}'"
   count = 3
-  m = text.match(/^bottom(?<count>\d+)/)
+  m = text.match(/^!bottom(?<count>\d+)/)
   if (m)
-    count = m[:count].to_int
+    count = m[:count].to_i
   end
 
   sth = $client.prepare("SELECT thing,points FROM `#{$tablename}` ORDER BY points ASC, thing ASC LIMIT #{count};")
-  sth.execute()
+  results = sth.execute()
   str = ""
   rank = 1
-  sth.fetch do |row|
+  results.each do |row|
     thing = "#{row['thing']}".force_encoding('utf-8').gsub('"','&quot;')
     str += "#{rank}. \"#{thing}\" (#{row['points']}) "
   end
-  dbh.disconnect()
 
   if(str != "")
     sendMessage(str,channel)

--- a/karmabot.rb
+++ b/karmabot.rb
@@ -87,9 +87,13 @@ end
 
 def doKarma(text,channel,user)
   puts "checking karma for '#{text}'"
-  #chop off the '!karma'
-  text = text[7..text.length]
-  puts "after chopping text is '#{text}'"
+
+  if(text.match(/^!karma\b/))
+    #chop off the '!karma'
+    text = text[7..text.length]
+    puts "after chopping text is '#{text}'"
+  end
+
   if(!text || text.match(/^\s*$/))
     puts "blank input - replacing with username (#{user})"
     text = user

--- a/karmabot.rb
+++ b/karmabot.rb
@@ -125,7 +125,7 @@ def doTop(text,channel,user)
     count = m[:count].to_int
   end
 
-  sth = $client.prepare("SELECT thing,points FROM `#{tablename}` ORDER BY points DESC, thing ASC LIMIT #{count};")
+  sth = $client.prepare("SELECT thing,points FROM `#{$tablename}` ORDER BY points DESC, thing ASC LIMIT #{count};")
   sth.execute()
   str = ""
   rank = 1
@@ -151,7 +151,7 @@ def doBottom(text,channel,user)
     count = m[:count].to_int
   end
 
-  sth = $client.prepare("SELECT thing,points FROM `#{tablename}` ORDER BY points ASC, thing ASC LIMIT #{count};")
+  sth = $client.prepare("SELECT thing,points FROM `#{$tablename}` ORDER BY points ASC, thing ASC LIMIT #{count};")
   sth.execute()
   str = ""
   rank = 1


### PR DESCRIPTION
Converted `handleFetch` into a generic command dispatch. `doKarma` now gets the karma scores of one or more phrases.

`doTop` and `doBottom` implement `!topX` and `!bottomY`, respectively.

Could also change to `!top X` and `!bottom Y`, probably with a simple addition to the regex.

Closes #5 